### PR TITLE
Adding more client builder options to specify base client url

### DIFF
--- a/okta/user_test.go
+++ b/okta/user_test.go
@@ -113,8 +113,9 @@ func setupTestUsers() {
 			ZipCode:           "94107",
 			CountryCode:       "US"},
 		Credentials: credentials{
-			RecoveryQuestion: recoveryQuestion{Question: "Who's a major player in the cowboy scene?"},
-			Provider: provider{Type: "OKTA",
+			Password:         &passwordValue{},
+			RecoveryQuestion: &recoveryQuestion{Question: "Who's a major player in the cowboy scene?"},
+			Provider: &provider{Type: "OKTA",
 				Name: "OKTA"},
 		},
 	}


### PR DESCRIPTION
Currently there is no mechanism to provide alternate base domains to the base client url.  Domains, such as okta-emea.com, cannot currently be supported with this library.