### PR TITLE
Context

### DIFF
--- a/examples/groupExamples.go
+++ b/examples/groupExamples.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"github.com/chrismalek/oktasdk-go/okta"
+	"github.com/nzoschke/oktasdk-go/okta"
 )
 
 func searchForGroupByName() {
@@ -17,7 +18,7 @@ func searchForGroupByName() {
 	groupFilterOptions := new(okta.GroupFilterOptions)
 	groupFilterOptions.GetAllPages = true
 	groupFilterOptions.NameStartsWith = "TEST"
-	groupSearchResult, response, err := client.Groups.ListWithFilter(groupFilterOptions)
+	groupSearchResult, response, err := client.Groups.ListWithFilter(context.Background(), groupFilterOptions)
 
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
@@ -41,7 +42,7 @@ func getFirst3PageOfOKTAGroupsUpdatedRecently() {
 	groupFilterOptions.LastUpdated.Value = time.Now().AddDate(0, -1, 0) // Last Month
 	groupFilterOptions.LastUpdated.Operator = okta.FilterGreaterThanOperator
 
-	groupSearchResult, response, err := client.Groups.ListWithFilter(groupFilterOptions)
+	groupSearchResult, response, err := client.Groups.ListWithFilter(context.Background(), groupFilterOptions)
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
 	} else {
@@ -57,7 +58,7 @@ func getGroupByID() {
 	defer printEnd(printStart("getGroupByID"))
 	client := okta.NewClient(nil, orgName, apiToken, isProductionOKTAORG)
 
-	group, response, err := client.Groups.GetByID("00g2nlq3l6DDWPIYBOTG")
+	group, response, err := client.Groups.GetByID(context.Background(), "00g2nlq3l6DDWPIYBOTG")
 
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
@@ -81,7 +82,7 @@ func getRandomOKTAGroupUser() {
 	groupFilterOptions.LastMembershipUpdated.Value = time.Now().AddDate(0, -1, 0) // Last Month
 	groupFilterOptions.LastMembershipUpdated.Operator = okta.FilterGreaterThanOperator
 
-	groupSearchResult, response, err := client.Groups.ListWithFilter(groupFilterOptions)
+	groupSearchResult, response, err := client.Groups.ListWithFilter(context.Background(), groupFilterOptions)
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
 
@@ -92,7 +93,7 @@ func getRandomOKTAGroupUser() {
 			groupUserOptions := new(okta.GroupUserFilterOptions)
 			groupUserOptions.GetAllPages = true
 
-			userList, response, err := client.Groups.GetUsers(groupSearchResult[0].ID, groupUserOptions)
+			userList, response, err := client.Groups.GetUsers(context.Background(), groupSearchResult[0].ID, groupUserOptions)
 			if err != nil {
 				fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
 
@@ -113,7 +114,7 @@ func groupAddAndDelete() {
 	groupName := "OKTASDK-GO-" + time.Now().String()
 	groupDescription := "Created by OKTASDK-GO @ " + time.Now().String()
 
-	newGroup, response, err := client.Groups.Add(groupName, groupDescription)
+	newGroup, response, err := client.Groups.Add(context.Background(), groupName, groupDescription)
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
 		return
@@ -122,7 +123,7 @@ func groupAddAndDelete() {
 	printGroup(*newGroup)
 
 	fmt.Printf("Deleting New Group ID: %v\n", newGroup.ID)
-	response, err = client.Groups.Delete(newGroup.ID)
+	response, err = client.Groups.Delete(context.Background(), newGroup.ID)
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
 		return

--- a/examples/main.go
+++ b/examples/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/chrismalek/oktasdk-go/okta"
+	"github.com/nzoschke/oktasdk-go/okta"
 )
 
 var orgName = os.Getenv("OKTA_API_TEST_ORG")

--- a/examples/userExamples.go
+++ b/examples/userExamples.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/chrismalek/oktasdk-go/okta"
+	"github.com/nzoschke/oktasdk-go/okta"
 )
 
 func nameSearchExample() {
@@ -19,7 +20,7 @@ func nameSearchExample() {
 	userFilter := &okta.UserListFilterOptions{}
 	userFilter.FirstNameEqualTo = "Chris"
 	userFilter.LastNameEqualTo = "Malek"
-	userList, response, err := client.Users.ListWithFilter(userFilter)
+	userList, response, err := client.Users.ListWithFilter(context.Background(), userFilter)
 
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
@@ -46,7 +47,7 @@ func getActiveUsersExampleOnePageAtATime() {
 	for {
 
 		i++
-		userPage, response, err := client.Users.ListWithFilter(userFilter)
+		userPage, response, err := client.Users.ListWithFilter(context.Background(), userFilter)
 
 		if err != nil {
 			fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
@@ -79,7 +80,7 @@ func getActiveUsersExampleAllPages() {
 	userFilter.GetAllPages = true
 	userFilter.StatusEqualTo = okta.UserStatusActive
 
-	allUsers, response, err := client.Users.ListWithFilter(userFilter)
+	allUsers, response, err := client.Users.ListWithFilter(context.Background(), userFilter)
 
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
@@ -104,7 +105,7 @@ func getActiveUserUpdatedInLastMonthAllPages() {
 	userFilter.LastUpdated.Value = time.Now().AddDate(0, -1, 0)
 	userFilter.LastUpdated.Operator = okta.FilterGreaterThanOperator
 
-	allUsers, response, err := client.Users.ListWithFilter(userFilter)
+	allUsers, response, err := client.Users.ListWithFilter(context.Background(), userFilter)
 
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
@@ -126,7 +127,7 @@ func getFirstActiveUserRoles() {
 	userFilter.Limit = 1
 	userFilter.StatusEqualTo = okta.UserStatusActive
 
-	randomActiveUsers, response, err := client.Users.ListWithFilter(userFilter)
+	randomActiveUsers, response, err := client.Users.ListWithFilter(context.Background(), userFilter)
 
 	if err != nil {
 		fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
@@ -135,7 +136,7 @@ func getFirstActiveUserRoles() {
 	fmt.Printf("len(all_users) = %v\n", len(randomActiveUsers))
 	printUserArray(randomActiveUsers)
 	if len(randomActiveUsers) > 0 {
-		response, err := client.Users.PopulateGroups(&randomActiveUsers[0])
+		response, err := client.Users.PopulateGroups(context.Background(), &randomActiveUsers[0])
 		if err != nil {
 			fmt.Printf("Response Error %+v\n\t URL used:%v\n", err, response.Request.URL.String())
 		}
@@ -162,7 +163,7 @@ func createUserNoPassword() {
 	fmt.Printf("User Json\n\t%v\n\n", string(jsonTest))
 	createNewUserAsActive := false
 
-	newUser, _, err := client.Users.Create(newUserTemplate, createNewUserAsActive)
+	newUser, _, err := client.Users.Create(context.Background(), newUserTemplate, createNewUserAsActive)
 
 	if err != nil {
 
@@ -194,7 +195,7 @@ func createUserWithPassword() {
 	fmt.Printf("User Json\n\t%v\n\n", string(jsonTest))
 
 	createNewUserAsActive := true
-	newUser, _, err := client.Users.Create(newUserTemplate, createNewUserAsActive)
+	newUser, _, err := client.Users.Create(context.Background(), newUserTemplate, createNewUserAsActive)
 
 	if err != nil {
 
@@ -231,7 +232,7 @@ func createUserWithRecoveryAndPassword() {
 	fmt.Printf("User Json\n\t%v\n\n", string(jsonTest))
 
 	createNewUserAsActive := true
-	newUser, _, err := client.Users.Create(newUserTemplate, createNewUserAsActive)
+	newUser, _, err := client.Users.Create(context.Background(), newUserTemplate, createNewUserAsActive)
 
 	if err != nil {
 
@@ -263,7 +264,7 @@ func CreateUserThenActivate() {
 	fmt.Printf("User Json\n\t%v\n\n", string(jsonTest))
 
 	createNewUserAsActive := false
-	newUser, _, err := client.Users.Create(newUserTemplate, createNewUserAsActive)
+	newUser, _, err := client.Users.Create(context.Background(), newUserTemplate, createNewUserAsActive)
 
 	if err != nil {
 
@@ -274,7 +275,7 @@ func CreateUserThenActivate() {
 	fmt.Printf("NewUser Created\n")
 	printUser(*newUser)
 	sendEmail := false
-	activationInfo, _, err := client.Users.Activate(newUser.ID, sendEmail)
+	activationInfo, _, err := client.Users.Activate(context.Background(), newUser.ID, sendEmail)
 
 	if err != nil {
 		fmt.Printf("Error Activating User:\n \t%v\n", err)
@@ -290,7 +291,7 @@ func SetUserPassword() {
 
 	client := okta.NewClient(nil, orgName, apiToken, isProductionOKTAORG)
 
-	newUser, _, err := client.Users.SetPassword("00u8cmwszdE5qztLT0h7", "heRo.laKe.ransOm.23.dogfoOd")
+	newUser, _, err := client.Users.SetPassword(context.Background(), "00u8cmwszdE5qztLT0h7", "heRo.laKe.ransOm.23.dogfoOd")
 
 	if err != nil {
 		fmt.Printf("Error Setting Password On User:\n \t%v\n", err)
@@ -305,7 +306,7 @@ func deactivateUser() {
 	defer printEnd(printStart("deactivateUser"))
 
 	client := okta.NewClient(nil, orgName, apiToken, isProductionOKTAORG)
-	_, err := client.Users.Deactivate("00u8cmwszdE5qztLT0h7")
+	_, err := client.Users.Deactivate(context.Background(), "00u8cmwszdE5qztLT0h7")
 	if err != nil {
 		fmt.Printf("Could Not deactivate user:\n%v\n", err)
 		return
@@ -318,20 +319,20 @@ func getUserMFAFactor(oktaid string) {
 	defer printEnd(printStart("getUserMFAFactor"))
 
 	client := okta.NewClient(nil, orgName, apiToken, isProductionOKTAORG)
-	user, _, err := client.Users.GetByID(oktaid)
+	user, _, err := client.Users.GetByID(context.Background(), oktaid)
 
 	if err != nil {
 		fmt.Printf("Errr Getting Users:\n \t%v\n", err)
 		return
 	}
 
-	_, err = client.Users.PopulateMFAFactors(user)
+	_, err = client.Users.PopulateMFAFactors(context.Background(), user)
 
 	if err != nil {
 		fmt.Printf("Errr Getting MFA Factors:\n \t%v\n", err)
 		return
 	}
-	_, err = client.Users.PopulateGroups(user)
+	_, err = client.Users.PopulateGroups(context.Background(), user)
 	if err != nil {
 		fmt.Printf("Errr Getting Groups:\n \t%v\n", err)
 		return
@@ -344,14 +345,14 @@ func getUser(oktaid string) {
 	defer printEnd(printStart("getUser"))
 
 	client := okta.NewClient(nil, orgName, apiToken, isProductionOKTAORG)
-	user, _, err := client.Users.GetByID(oktaid)
+	user, _, err := client.Users.GetByID(context.Background(), oktaid)
 
 	if err != nil {
 		fmt.Printf("Errr Getting Users:\n \t%v\n", err)
 		return
 	}
 
-	_, err = client.Users.PopulateGroups(user)
+	_, err = client.Users.PopulateGroups(context.Background(), user)
 	if err != nil {
 		fmt.Printf("Errr Getting Groups:\n \t%v\n", err)
 		return

--- a/okta/apps.go
+++ b/okta/apps.go
@@ -1,6 +1,7 @@
 package okta
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"time"
@@ -120,7 +121,7 @@ func (a App) String() string {
 }
 
 // GetByID gets a group from OKTA by the Gropu ID. An error is returned if the group is not found
-func (a *AppsService) GetByID(appID string) (*App, *Response, error) {
+func (a *AppsService) GetByID(ctx context.Context, appID string) (*App, *Response, error) {
 
 	u := fmt.Sprintf("apps/%v", appID)
 	req, err := a.client.NewRequest("GET", u, nil)
@@ -131,7 +132,7 @@ func (a *AppsService) GetByID(appID string) (*App, *Response, error) {
 
 	app := new(App)
 
-	resp, err := a.client.Do(req, app)
+	resp, err := a.client.Do(ctx, req, app)
 
 	if err != nil {
 		return nil, resp, err
@@ -180,7 +181,7 @@ type AppUser struct {
 // GetUsers returns the members in an App
 //   Pass in an optional AppFilterOptions struct to filter the results
 //   The Users in the app are returned
-func (a *AppsService) GetUsers(appID string, opt *AppFilterOptions) (appUsers []AppUser, resp *Response, err error) {
+func (a *AppsService) GetUsers(ctx context.Context, appID string, opt *AppFilterOptions) (appUsers []AppUser, resp *Response, err error) {
 
 	pagesRetreived := 0
 	var u string
@@ -202,7 +203,7 @@ func (a *AppsService) GetUsers(appID string, opt *AppFilterOptions) (appUsers []
 		fmt.Printf("____ERROR HERE\n")
 		return nil, nil, err
 	}
-	resp, err = a.client.Do(req, &appUsers)
+	resp, err = a.client.Do(ctx, req, &appUsers)
 
 	if err != nil {
 		fmt.Printf("____ERROR HERE 2\n")
@@ -226,7 +227,7 @@ func (a *AppsService) GetUsers(appID string, opt *AppFilterOptions) (appUsers []
 				pageOpts.Limit = opt.Limit
 				pageOpts.NumberOfPages = 1
 
-				userPage, resp, err = a.GetUsers(appID, pageOpts)
+				userPage, resp, err = a.GetUsers(ctx, appID, pageOpts)
 
 				if err != nil {
 					return appUsers, resp, err

--- a/okta/groups.go
+++ b/okta/groups.go
@@ -1,6 +1,7 @@
 package okta
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -80,7 +81,7 @@ func (g Group) String() string {
 
 // ListWithFilter - Method to list groups with different filter options.
 //  Pass in a GroupFilterOptions to specify filters. Values in that struct will turn into Query parameters
-func (g *GroupsService) ListWithFilter(opt *GroupFilterOptions) ([]Group, *Response, error) {
+func (g *GroupsService) ListWithFilter(ctx context.Context, opt *GroupFilterOptions) ([]Group, *Response, error) {
 
 	var u string
 	var err error
@@ -118,7 +119,7 @@ func (g *GroupsService) ListWithFilter(opt *GroupFilterOptions) ([]Group, *Respo
 		return nil, nil, err
 	}
 	groups := make([]Group, 1)
-	resp, err := g.client.Do(req, &groups)
+	resp, err := g.client.Do(ctx, req, &groups)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -138,7 +139,7 @@ func (g *GroupsService) ListWithFilter(opt *GroupFilterOptions) ([]Group, *Respo
 				pageOption.NumberOfPages = 1
 				pageOption.Limit = opt.Limit
 
-				groupPage, resp, err = g.ListWithFilter(pageOption)
+				groupPage, resp, err = g.ListWithFilter(ctx, pageOption)
 				if err != nil {
 					return groups, resp, err
 				}
@@ -154,7 +155,7 @@ func (g *GroupsService) ListWithFilter(opt *GroupFilterOptions) ([]Group, *Respo
 }
 
 // GetByID gets a group from OKTA by the Gropu ID. An error is returned if the group is not found
-func (g *GroupsService) GetByID(groupID string) (*Group, *Response, error) {
+func (g *GroupsService) GetByID(ctx context.Context, groupID string) (*Group, *Response, error) {
 
 	u := fmt.Sprintf("groups/%v", groupID)
 	req, err := g.client.NewRequest("GET", u, nil)
@@ -165,7 +166,7 @@ func (g *GroupsService) GetByID(groupID string) (*Group, *Response, error) {
 
 	group := new(Group)
 
-	resp, err := g.client.Do(req, group)
+	resp, err := g.client.Do(ctx, req, group)
 
 	if err != nil {
 		return nil, resp, err
@@ -177,7 +178,7 @@ func (g *GroupsService) GetByID(groupID string) (*Group, *Response, error) {
 // GetUsers returns the members in a group
 //   Pass in an optional GroupFilterOptions struct to filter the results
 //   The Users in the group are returned
-func (g *GroupsService) GetUsers(groupID string, opt *GroupUserFilterOptions) (users []User, resp *Response, err error) {
+func (g *GroupsService) GetUsers(ctx context.Context, groupID string, opt *GroupUserFilterOptions) (users []User, resp *Response, err error) {
 	pagesRetreived := 0
 	var u string
 	if opt.NextURL != nil {
@@ -197,7 +198,7 @@ func (g *GroupsService) GetUsers(groupID string, opt *GroupUserFilterOptions) (u
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err = g.client.Do(req, &users)
+	resp, err = g.client.Do(ctx, req, &users)
 
 	if err != nil {
 		return nil, resp, err
@@ -219,7 +220,7 @@ func (g *GroupsService) GetUsers(groupID string, opt *GroupUserFilterOptions) (u
 				pageOpts.Limit = opt.Limit
 				pageOpts.NumberOfPages = 1
 
-				userPage, resp, err = g.GetUsers(groupID, pageOpts)
+				userPage, resp, err = g.GetUsers(ctx, groupID, pageOpts)
 				if err != nil {
 					return users, resp, err
 				}
@@ -236,7 +237,7 @@ func (g *GroupsService) GetUsers(groupID string, opt *GroupUserFilterOptions) (u
 }
 
 // Add - Adds an OKTA Mastered Group with name and description. GroupName is required.
-func (g *GroupsService) Add(groupName string, groupDescription string) (*Group, *Response, error) {
+func (g *GroupsService) Add(ctx context.Context, groupName string, groupDescription string) (*Group, *Response, error) {
 
 	if groupName == "" {
 		return nil, nil, errors.New("groupName parameter is required for ADD")
@@ -256,7 +257,7 @@ func (g *GroupsService) Add(groupName string, groupDescription string) (*Group, 
 
 	group := new(Group)
 
-	resp, err := g.client.Do(req, group)
+	resp, err := g.client.Do(ctx, req, group)
 
 	if err != nil {
 		return nil, resp, err
@@ -266,7 +267,7 @@ func (g *GroupsService) Add(groupName string, groupDescription string) (*Group, 
 }
 
 // Delete - Delets an OKTA Mastered Group with ID
-func (g *GroupsService) Delete(groupID string) (*Response, error) {
+func (g *GroupsService) Delete(ctx context.Context, groupID string) (*Response, error) {
 
 	if groupID == "" {
 		return nil, errors.New("groupID parameter is required for Delete")
@@ -279,7 +280,7 @@ func (g *GroupsService) Delete(groupID string) (*Response, error) {
 		return nil, err
 	}
 
-	resp, err := g.client.Do(req, nil)
+	resp, err := g.client.Do(ctx, req, nil)
 
 	if err != nil {
 		return resp, err

--- a/okta/sdk.go
+++ b/okta/sdk.go
@@ -2,6 +2,7 @@ package okta
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -238,7 +239,8 @@ func parseRate(r *http.Response) Rate {
 // interface, the raw response body will be written to v, without attempting to
 // first decode it.  If rate limit is exceeded and reset time is in the future,
 // Do returns rate immediately without making a network API call.
-func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
+func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Response, error) {
+	req = req.WithContext(ctx)
 
 	// If we've hit rate limit, don't make further requests before Reset time.
 	if err := c.checkRateLimitBeforeDo(req); err != nil {

--- a/okta/sdk_test.go
+++ b/okta/sdk_test.go
@@ -1,6 +1,7 @@
 package okta
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -112,7 +113,7 @@ func TestRateLimitRateExceededError(t *testing.T) {
 		t.Errorf("Error Creating Client: %v\n", err)
 	}
 
-	_, err = client.Do(req, nil)
+	_, err = client.Do(context.Background(), req, nil)
 
 	if err != nil {
 		t.Errorf("Error doing GET Test: %v\n", err)
@@ -127,7 +128,7 @@ func TestRateLimitRateExceededError(t *testing.T) {
 		t.Errorf("client.mostRecentRate.RatePerMinuteLimit was not cached. Expected %v, Got: %v", client.mostRecentRate.RatePerMinuteLimit, headerRateLimitWant)
 	}
 	// Second Call should return an error becasue it has cached the values
-	_, err = client.Do(req, nil)
+	_, err = client.Do(context.Background(), req, nil)
 
 	if err == nil {
 		t.Errorf("Expected Rate Limit Error To be Returned. However, No Error was created.\n")
@@ -137,7 +138,7 @@ func TestRateLimitRateExceededError(t *testing.T) {
 	// In our test we should really only have to wait 3 seconds and NOT get an error.
 	client.PauseOnRateLimit = true
 
-	_, err = client.Do(req, nil)
+	_, err = client.Do(context.Background(), req, nil)
 
 	if err != nil {
 		t.Errorf("We expected the client to pause for 3 seconds. However, it looks like an error was return.\n")
@@ -148,7 +149,7 @@ func TestRateLimitRateExceededError(t *testing.T) {
 	client.PauseOnRateLimit = false
 	client.RateRemainingFloor = 2
 
-	_, err = client.Do(req, nil)
+	_, err = client.Do(context.Background(), req, nil)
 
 	if err != nil {
 		t.Errorf("Expected nil Rate Limit Error after reconfiguring client for a floor of 2. However, an error was still return.\n")

--- a/okta/user_test.go
+++ b/okta/user_test.go
@@ -1,6 +1,7 @@
 package okta
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -141,7 +142,7 @@ func TestUserGet(t *testing.T) {
 		fmt.Fprint(w, userTestJSONString)
 	})
 
-	user, _, err := client.Users.GetByID("00ub0oNGTSWTBKOLGLNR")
+	user, _, err := client.Users.GetByID(context.Background(), "00ub0oNGTSWTBKOLGLNR")
 	if err != nil {
 		t.Errorf("Users.Get returned error: %v", err)
 	}


### PR DESCRIPTION
This patch adds the context pattern to the SDK. This is a **breaking change** to the package API.

However, this preserves the spirit of mimicking the go-github package which introduced context as the first argument to every SDK call in Feb 2017: https://github.com/google/go-github/pull/529

This was prompted by using this SDK in an AWS Lambda function that traces all HTTP activity with X-Ray.